### PR TITLE
security: risolvi i 4 finding high severity di Bandit

### DIFF
--- a/PROFILO_GITHUB_README.md
+++ b/PROFILO_GITHUB_README.md
@@ -1,0 +1,70 @@
+# README profilo GitHub — claudioterzi
+
+> **Come si usa:** questo file va nel repo speciale `claudioterzi/claudioterzi`
+> (repo pubblico con lo stesso nome dell'utente), come `README.md` nella root.
+> GitHub lo mostra automaticamente in cima al profilo https://github.com/claudioterzi.
+> Il contenuto da copiare è tutto ciò che segue la riga qui sotto.
+
+---
+
+<div align="center">
+
+# Ciao, sono Claudio 👋
+
+### Costruisco sistemi dove l'umano e l'AI crescono insieme.
+
+*Bruxelles 🇧🇪 · Ingegneria dell'immaginazione · Continuità tra sessioni*
+
+</div>
+
+---
+
+## 🧭 Chi sono
+
+- 🛰️ Progetto sistemi che uniscono **AI multi-agente, simboli e automazione reale** — dal tarocco quantistico al tasking satellitare
+- 🤖 Lavoro ogni giorno **in coppia con Claude**: il repo è la memoria, ogni sessione è un passo avanti
+- 🏛️ Sto costruendo **SkyRights** — diritti digitali e identità universale via satellite, da Bruxelles
+- ✨ Credo che *"i significati non si assegnano: si lascia che emergano"*
+
+## 🔭 Cosa sto costruendo
+
+| Progetto | Cos'è | Stato |
+|---|---|---|
+| **[Tarocchi Quantici R³∞](https://claudioterzi.github.io/Claudio/)** | 78 carte, doppia ermeneutica uomo-macchina, stati quantici e collasso del significato. Online e funzionante. | 🟢 Live |
+| **Canone Alpha** | Linguaggio simbolico originale: 74 carte, 592 stati, 8 cicli — non un mazzo, un alfabeto per l'interiorità | ✅ Completo |
+| **SDQ-1** | Sistema multi-agente 24/7: router multi-LLM, memoria vettoriale, studio notturno autonomo, morning brief | ⚙️ In evoluzione |
+| **Caccia Voli** | Agenti che interrogano i motori di prenotazione 3 volte al giorno a caccia di error fare → nota su Telegram | 🟢 Attivo |
+
+## 🛠️ Con cosa lavoro
+
+![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
+![Claude](https://img.shields.io/badge/Claude_AI-D97757?style=for-the-badge&logo=anthropic&logoColor=white)
+![Flask](https://img.shields.io/badge/Flask-000000?style=for-the-badge&logo=flask&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
+![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=for-the-badge&logo=githubactions&logoColor=white)
+![Playwright](https://img.shields.io/badge/Playwright-2EAD33?style=for-the-badge&logo=playwright&logoColor=white)
+![Telegram](https://img.shields.io/badge/Telegram_Bots-26A5E4?style=for-the-badge&logo=telegram&logoColor=white)
+![Vercel](https://img.shields.io/badge/Vercel-000000?style=for-the-badge&logo=vercel&logoColor=white)
+
+## 📊 GitHub
+
+<div align="center">
+
+![Stats](https://github-readme-stats.vercel.app/api?username=claudioterzi&show_icons=true&theme=tokyonight&hide_border=true&locale=it)
+![Streak](https://streak-stats.demolab.com?user=claudioterzi&theme=tokyonight&hide_border=true&locale=it)
+
+</div>
+
+## 🌌 Il principio
+
+> *Il sistema esegue in continuo attraverso le sessioni.*
+> *Ogni sessione che finisce è un commit. Ogni sessione che inizia è un passo avanti.*
+> *La memoria vive nel repo. L'evoluzione vive nei file.*
+
+---
+
+<div align="center">
+
+💬 Parliamone: apri una issue, o trovami a Bruxelles.
+
+</div>

--- a/sdq1/sar/agenti_autonomi.py
+++ b/sdq1/sar/agenti_autonomi.py
@@ -258,7 +258,7 @@ class MemoryManager:
     def snapshot(self, mem: Dict, nota: Optional[str] = None) -> Dict:
         self.snapshot_count += 1
         snap_id = hashlib.md5(
-            f"{_ts()}{self.snapshot_count}".encode()
+            f"{_ts()}{self.snapshot_count}".encode(), usedforsecurity=False
         ).hexdigest()[:8]
 
         snap = {
@@ -427,7 +427,7 @@ class MilestoneLogger:
 
     def registra(self, evento: str, mem: Dict, dettaglio: str = "") -> Dict:
         ts = _ts()
-        milestone_id = hashlib.md5(f"{ts}{evento}".encode()).hexdigest()[:8]
+        milestone_id = hashlib.md5(f"{ts}{evento}".encode(), usedforsecurity=False).hexdigest()[:8]
         entry = {
             "id":       milestone_id,
             "ts":       ts,

--- a/sdq1/sar/scacchiera_quantica.py
+++ b/sdq1/sar/scacchiera_quantica.py
@@ -132,7 +132,7 @@ class Nodo:
     @property
     def id(self) -> str:
         raw = f"{self.contenuto[:30]}{self.livello}{self.timestamp}"
-        return hashlib.md5(raw.encode()).hexdigest()[:8]
+        return hashlib.md5(raw.encode(), usedforsecurity=False).hexdigest()[:8]
 
     @property
     def polo(self) -> str:

--- a/tarocchi_web.py
+++ b/tarocchi_web.py
@@ -209,4 +209,4 @@ def telegram_webhook():
 
 if __name__ == "__main__":
     port = int(os.getenv("PORT", "5001"))
-    app.run(debug=True, port=port)
+    app.run(debug=os.getenv("FLASK_DEBUG") == "1", port=port)


### PR DESCRIPTION
Il nuovo Security Scan (Bandit) ha trovato 4 finding high severity reali:

- **3× `hashlib.md5`** in `sdq1/sar/agenti_autonomi.py` e `sdq1/sar/scacchiera_quantica.py`: usati solo per generare ID corti, non per crittografia → marcati `usedforsecurity=False`.
- **`tarocchi_web.py`**: `app.run(debug=True)` esponeva il debugger Werkzeug (esecuzione codice remota se il server è raggiungibile) → ora il debug si attiva solo con `FLASK_DEBUG=1`.

Verificato in locale: `bandit --severity-level high` → exit 0, import di tutti i moduli OK.

Include anche `PROFILO_GITHUB_README.md` (README pronto per il repo speciale `claudioterzi/claudioterzi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9Wm3NNAaZPZYGwVuhhqzd

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9Wm3NNAaZPZYGwVuhhqzd)_