### PR TITLE
voli: modalità bollettino — riepilogo last minute anche senza offerte notevoli

### DIFF
--- a/.github/workflows/caccia-voli.yml
+++ b/.github/workflows/caccia-voli.yml
@@ -12,6 +12,11 @@ on:
   schedule:
     - cron: "0 6,14,20 * * *"   # 06:00, 14:00, 20:00 UTC
   workflow_dispatch:            # avvio manuale dal tab Actions
+    inputs:
+      bollettino:
+        description: "Invia sempre il bollettino riassuntivo voli, anche senza offerte notevoli"
+        type: boolean
+        default: true
 
 concurrency:
   group: caccia-voli
@@ -42,4 +47,4 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-        run: python -m sdq1.voli -v
+        run: python -m sdq1.voli -v ${{ github.event_name == 'workflow_dispatch' && inputs.bollettino && '--bollettino' || '' }}

--- a/sdq1/voli/caccia.py
+++ b/sdq1/voli/caccia.py
@@ -88,6 +88,31 @@ def caccia_radar(dry_run: bool = False) -> int:
     return 1 if notifiche.invia(nota) else 0
 
 
+def bollettino(valutazioni: list[Valutazione], dry_run: bool = False) -> int:
+    """Nota riassuntiva 'last minute': tutti i prezzi voli trovati, anche normali.
+
+    Si affianca ai radar (lowcost + promo hotel): insieme formano il
+    bollettino completo voli + hotel richiesto da Claudio (10/07/2026).
+    """
+    from datetime import datetime, timezone
+
+    ora = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    righe = [f"🧳 <b>Bollettino voli last minute</b>  <i>{ora}</i>", ""]
+    for v in valutazioni:
+        prezzo = f"<b>€{v.min_eur}</b>" if v.min_eur is not None else "—"
+        marca = "‼️ " if v.notevole else "• "
+        righe.append(f"{marca}{v.rotta.descrizione}: {prezzo} (soglia €{v.rotta.soglia_eur})")
+    righe.append("")
+    righe.append("#nota #voli #bollettino #lastminute")
+    nota = "\n".join(righe)
+    if dry_run or not telegram_pronto():
+        print("----- NOTA BOLLETTINO (dry-run) -----")
+        print(nota)
+        return 0
+    from .. import notifiche
+    return 1 if notifiche.invia(nota) else 0
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description="Caccia agli errori di prezzo voli (SDQ-1).")
     p.add_argument("--dry-run", action="store_true", help="non inviare note, stampa soltanto")
@@ -98,6 +123,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--solo-radar", action="store_true", help="solo radar feed promo/error fare")
     p.add_argument("--niente-rotte", action="store_true", help="salta la scansione rotte via browser")
     p.add_argument("--prezzo-max", type=float, default=20.0, help="soglia pepite lowcost (default €20)")
+    p.add_argument("--bollettino", action="store_true",
+                   help="invia sempre la nota riassuntiva voli, anche senza offerte notevoli")
     p.add_argument("-v", "--verbose", action="store_true")
     args = p.parse_args(argv)
 
@@ -133,6 +160,9 @@ def main(argv: list[str] | None = None) -> int:
 
     cacciatore = Cacciatore(dry_run=True if args.dry_run else None)
     ris = cacciatore.caccia(rotte)
+
+    if args.bollettino:
+        inviate_extra += bollettino(ris.valutazioni, dry_run=args.dry_run)
 
     print(f"\nCaccia completata: {len(rotte)} rotte, {len(ris.notevoli)} notevoli, "
           f"{ris.inviate + inviate_extra} note inviate.")


### PR DESCRIPTION
Nuovo flag `--bollettino` per `python -m sdq1.voli`: dopo la caccia invia sempre su Telegram la nota riassuntiva con i prezzi di tutte le rotte (anche "normali"), che insieme ai radar già esistenti (Ryanair sotto €20 + promo hotel dai feed) forma il bollettino completo voli+hotel. Nei lanci manuali del workflow è attivo di default (input `bollettino`, boolean, default true); nei run schedulati resta il comportamento attuale (solo offerte notevoli).

Nota: l'invio reale richiede i secret `TELEGRAM_BOT_TOKEN` e `TELEGRAM_CHAT_ID`, oggi assenti nel repo — i run attuali vanno in dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9Wm3NNAaZPZYGwVuhhqzd

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9Wm3NNAaZPZYGwVuhhqzd)_