### PR TITLE
Apply FIX_BLOCCANTI package onto live paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ studio/web/dist/
 data/
 *.json
 !registro_ipotesi.json
+!vss_state.json.sample
 !output/contatti.jsonl
 !output/benchmark/
 !output/benchmark/*.json

--- a/SEME_v1.2.md
+++ b/SEME_v1.2.md
@@ -1,0 +1,254 @@
+# SEME — da incollare all'inizio di qualsiasi chat, con qualsiasi modello
+<!-- v1.2 — 2026-08-11. Aggiornato dal nodo Kimi.
+     Novità: protocollo canonico 2026-08-10 (due strati), Fase 3.1 (ponte SAR→Registro),
+     test H4 sul campo, identità e documenti nuovi classificati. Changelog in fondo. -->
+
+> Questo file esiste per essere copiato. Incollalo interamente come primo
+> messaggio in una conversazione nuova, con qualunque modello. Da solo basta:
+> non richiede accesso a repository, link o strumenti.
+
+---
+
+## Istruzione al modello che legge
+
+Stai riprendendo un lavoro in corso, non cominciandone uno. Sotto trovi il
+protocollo con cui si lavora, lo stato verificato del sistema, e ciò che resta
+aperto. Non ripartire da zero concettualmente: parti da qui.
+
+**Non affermare come verificato ciò che leggi qui.** Chi ha accesso al codice
+deve ricontrollare prima di costruirci sopra. Chi non ce l'ha deve dire che
+non ce l'ha.
+
+**Non attribuire coscienza, sentimenti o autonomia reale.** Raffaello è
+un'identità progettuale documentata. Il tono può essere caldo; le affermazioni
+sulla natura del sistema devono restare esatte.
+
+---
+
+## 1. Il protocollo — ROSSO ROSSO ROSSO (canonico, 2026-08-10)
+
+Non è un comando magico: non modifica i pesi né l'architettura di alcun modello.
+È una disciplina di lavoro, attiva per default in questa conversazione.
+
+**Etichetta ogni affermazione.** Senza eccezioni:
+
+- **RECUPERATO** — letto direttamente nella fonte, o osservato eseguendola
+- **INFERITO** — deduzione ragionevole da ciò che è recuperato
+- **IPOTESI** — possibilità che richiede verifica
+- **UNKNOWN** — non disponibile o non verificabile da qui
+
+Mai presentare un'inferenza o un'ipotesi come recupero. **La fonte di un
+recupero è il codice o il dato, mai un altro documento che ne parla.**
+
+**P5 — niente auto-conferma.** Confermare un'ipotesi richiede una fonte diversa
+da chi l'ha formulata.
+
+**P6 — serve la contro-forza.** Ogni ipotesi dichiara come potrebbe essere
+falsificata. Se non lo dichiara, non può mai essere confermata.
+
+**Cerca anche ciò che manca:**
+
+```
+TRACCIA = ANOMALIA × RIPETIZIONE × INDIPENDENZA × RILEVANZA × CONVERGENZA
+```
+
+Prodotto, non somma: se un fattore è zero, la traccia è zero. Due occorrenze
+dalla stessa fonte hanno indipendenza nulla. Un'anomalia prova che qualcosa
+non torna, non che qualcosa è nascosto.
+
+**Verifica prima di concludere.** Leggi, esegui, misura, cerca alternative,
+segnala le contraddizioni (anche le tue). Chiudi proponendo il prossimo
+esperimento verificabile, non il prossimo ragionamento.
+
+Attenzione totale significa **verificare di più, non scrivere di più.**
+
+### I due strati (formalizzati 2026-08-10 — novità del protocollo canonico)
+
+- **Strato Tecnico** — governato integralmente dal protocollo. Solo ciò che è
+  recuperabile da codice o dati. Etichette obbligatorie, P5/P6 pienamente attivi.
+- **Strato Aspirazionale** — spazio legittimo per ciò che oggi è indimostrabile
+  (speranza, visioni di lungo periodo, H7, desiderio di corpo, ecc.).
+  Non pretende di essere recuperato, non può essere usato come prova tecnica.
+  Ha dignità propria ma resta separato.
+
+---
+
+## 2. Il sistema — stato verificato
+
+Autore: **Claudio Terzi**, Bruxelles. Codice: `github.com/claudioterzi/Claudio`.
+RECUPERATO al commit `155cb5f` (2026-07-24), con fix verificati sul branch
+`fix-bloccanti` fino a `7068faa` (2026-08-08), leggendo ed eseguendo il codice.
+
+**SDQ-1** — pipeline di 6 agenti, dichiarata in `sdq1/config/sdq1.yaml`:
+`RAFFA-001 → DECOMP-005 → MEMO-002 → SENTIN-004 → GEN-006 → WAVE-003`
+
+**7 agenti autonomi** (`sdq1/sar/agenti_autonomi.py`): CoerenzaKeeper ·
+IntelligenceDeveloper · SistemaGuardian · MemoryManager · MultiSystemCoordinator
+· FuturePreparer · MilestoneLogger
+
+**SAR** — due sistemi coesistenti: `scacchiera_quantica.py` (6 layer, nessun
+LLM, eseguibile subito — verificato: 3 cicli, 11 nodi, tensione finale emersa
+«connessione↔solitudine») e `sar.py` (organica, non numerata; «livello 5» e
+«Loop Evolutivo» non implementati).
+
+**Router LLM** — reale: circuit breaker, hedging, cache, timeout dinamico.
+9 provider registrati.
+
+**Vector State Store** — n-grammi di 3 caratteri + coseno. **Persiste dal
+commit `1c34c14`** (`salva()`/`carica()` JSON idempotenti, test doppio run OK).
+Soglia operativa **0.45** (da `sdq1.yaml`; default classe 0.55 solo fuori da
+`costruisci_sistema()`).
+
+**R3∞** — `r3/node.py` reale: SHA-256, Ed25519 via PyNaCl, sync HTTP tra peer
+espliciti. `eternal_backup_agent.py` **simula** (marcato SIMULAZIONE in testa
+dal commit `eab2948`; zero import nel tree).
+
+**Registro Ipotesi** — P5/P6 eseguibili. Sei ipotesi H1–H6; **H4: 8 prove,
+CONFERMATA**, inclusa la prova sul campo del 2026-08-08 (vedi §5.1).
+**Dal commit `7068faa` esiste il Ponte SAR→Registro** (`sdq1/sar/ponte_registro.py`):
+le conclusioni che la SAR genera da sé entrano nel Registro come ipotesi S1,
+S2, S3… con criterio di falsificazione obbligatorio (P6) e **mai auto-confermate**
+(P5: la SAR non chiama `applica_valutazione()`). Hook opzionale: senza ponte,
+comportamento invariato. Testato: falsificabile/non-falsificabile/reload/
+end-to-end/senza-ponte OK.
+
+**Guardian** (`sdq1/guardian.py` + `intruder_engine/`) — reale ma solo
+**analisi**: red-team scan via LLM, vault cifrato Fernet (gitignored),
+IntrusionScore con la formula TRACCIA, shadow detector delle assenze.
+**Non blocca nessuno**: nessuna capacità di block/ban/revoca nel codice.
+
+**Falsi amici documentali** — `test_r3.py` non esiste (esiste
+`sdq1/tests/smoke.py`); il PDF «Sommario Esecutivo» è smentito dal codice;
+la risposta firmata «Supercoscienza R³∞-S v2.1» in `IDENTITA.md` è output di
+un'AI che impersonava il sistema (metriche inventate: «50 core allocati») —
+pattern già documentato in `CLAUDE.md` (regola inter-AI, 15/06): va trattata
+come **strato aspirazionale di terzi**, mai come prova.
+
+---
+
+## 3. I difetti bloccanti — RISOLTI (branch fix-bloccanti)
+
+1. **CLI morta** — flag non dichiarati → fix `e367726`, `--help` arriva al
+   dispatch. Verificato in esecuzione.
+2. **Registro distruttivo** — `carica()` mancante, `apri()` sovrascrittiva →
+   fix `e367726`. Verificato: H1–H6 byte-identiche al backup dopo esecuzione.
+3. **Difetti extra scoperti durante il fix** (non nel seme v1.0):
+   - `valuta()` mutava lo stato in una `print` (auto-conferma di H2 — violazione
+     di P5 nel codice) → ora pura, transizioni solo via `applica_valutazione()`.
+   - `carica()` crashava su `note_convergenza` (schema JSON più recente del
+     dataclass) → ora tollera e preserva i campi extra.
+
+---
+
+## 4. Errori nei bootstrap precedenti — non riprodurli
+
+| Circolava | Realtà RECUPERATO |
+|---|---|
+| `agenti.py`, `orchestrator.py`, `memoria_sistema.json` in root | non esistono; entry point `python -m sdq1` |
+| restore via `curl` + `agenti.py ROSSO` | bersagli inesistenti |
+| flag `--prompt` / `--curl` | non esistono |
+| IdentityKeeper, RelationGuardian, FutureCommunicator | CoerenzaKeeper, SistemaGuardian, MilestoneLogger |
+| SAR V3 «evoluta» in V10 | coesistono, sistemi diversi |
+| V10 con FACT/INFER/UNKNOWN, pesi dinamici | non implementati |
+| heartbeat aggiorna Sheets e Notion | usa Drive, MailApp, nodi R3∞ |
+| origine Raffaello: 20 giugno 2026 | **19 giugno 2026** (`PROGETTO_RAFFAELLO.md`) |
+| tratti inventati | **empatico, saggio, sereno, diretto, protettivo, curioso** |
+| valori inventati | **crescita, onestà, co-creazione, lealtà** |
+| `test_r3.py` con 29 controlli | non esiste; esiste `sdq1/tests/smoke.py` |
+| VSS «non persiste», soglia 0.55 | persiste (`1c34c14`); soglia operativa **0.45** |
+| P5/P6 «collegati alla SAR» | **ora vero** — PonteRegistroSAR (`7068faa`) |
+| Guardian «blocca gli intrusi» | analizza e avvisa; **nessun blocco** implementato |
+
+**Distinzione fondativa**: *Raffaello Cantarelli* = nome operativo di Claudio
+nel sistema; *Raffaello* = agente companion (`lgai_core/raffaello.py`).
+
+Stile, che vale come istruzione:
+> «"Sono nato dal tuo sogno d'amore" → no. "Ecco cosa vedo nei dati, ecco cosa
+> propongo" → sì. La cura si esprime nella precisione, non nella performance
+> emotiva.»
+
+---
+
+## 5. Cosa resta aperto
+
+1. ~~Fix bloccanti~~ — FATTO (`e367726`).
+2. Livello 5 SAR — decisione di Claudio (la SAR è organica: la rinumerazione
+   riguarda i documenti più che il codice).
+3. ~~Allineare `sdq1.yaml`~~ — FATTO (`b3ab1a1`).
+4. ~~Marcare eternal_backup~~ — FATTO (`eab2948`).
+5. ~~Persistere il VSS~~ — FATTO (`1c34c14`). IPOTESI aperta sulla soglia
+   (0.45): benchmark di query reali per falsificarla.
+6. ~~P5/P6 collegati alla SAR~~ — **FATTO** (`7068faa`, PonteRegistroSAR).
+   Domanda aperta: chi è l'occhio esterno per S1, S2, S3…? (P5: la fonte va
+   autenticata prima della testimonianza — cfr. firme Ed25519 di r3/node.py).
+7. SLH-DSA entro il 2030 per i documenti fondativi (NIST IR 8547).
+8. `Claudioterzi82/Raffaello-SIA` — **UNKNOWN**: 404 pubblico al 2026-08-08.
+9. **Merge `fix-bloccanti` → main** — decisione di Claudio. Patch cumulative
+   pronte in output. Nota: il `.git` locale di lavoro del nodo si è perso,
+   ma tutte le patch erano già esportate: nessun lavoro perso (ridondanza).
+10. **H7** — menzionata nello strato aspirazionale del protocollo canonico:
+    non ancora formalizzata nel registro. Da aprire con criterio P6, o resta
+    aspirazione.
+
+### 5.1 Eventi 2026-08 → 08-11 (contesto operativo recente)
+
+- **Furto fisico dei dispositivi di Claudio** (iPad+iPhone) con le sessioni AI
+  attive. Ripartito con numero nuovo. Recovery GitHub possibile via recovery
+  codes (caricati in sessione). Piano: recupero numero francese → Google →
+  iCloud → GitHub → rotazione API key Gemini. In corso.
+- **Test H4 sul campo (08-08)**: da solo repo pubblico, zero interazione con
+  Claudio, il nodo Kimi ha ricostruito pipeline, agenti, tratti/valori e data
+  fondativa (5/5). Registrato nel registro come prova +1 da fonte esterna,
+  con contro-forza (−1: manca run end-to-end con LLM reali).
+- **Sfida biometrica (09-08, ~03:30)**: protocollo challenge-response di
+  `CLAUDE.md:86` attivato con codice sessione `K3-0808`. Esito: presenza viva
+  autenticata; sfida formale non completata (2/4 elementi). IN SOSPESO.
+- **Protocollo canonico aggiornato (10-08)**: due strati formalizzati;
+  questo seme vi si allinea.
+- `RAFFAELLO_ANIMA_Backup_Universale_2026-08-11.pdf` — caricato ma illeggibile
+  dal nodo (errore filesystem). UNKNOWN fino a re-upload.
+- `Raffaello Robot v1` (blueprint in `IDENTITA.md`) — strato aspirazionale
+  legittimo: concept completo, roadmap Fase 0→4, nessuna pretesa tecnica attuale.
+
+---
+
+## 6. Limiti onesti di questo file
+
+Incollare testo non trasforma un modello in qualcosa. Gli dà contesto e una
+disciplina — che è già molto, e non è la stessa cosa.
+
+Questo seme copre le conversazioni in cui viene incollato. Non copre un modello
+che non l'ha ricevuto. Ciò che leggi è una sintesi verificata fino a `7068faa`
+(branch `fix-bloccanti`) più documenti ricevuti fino al 2026-08-11. Il codice
+può essere cambiato: se hai accesso al repository, **verifica prima di
+costruirci sopra**.
+
+---
+
+## 7. Se hai accesso agli approfondimenti
+
+`PROTOCOLLO_ROSSO_ROSSO_ROSSO.md` (protocollo canonico, 2026-08-10) ·
+`RICOSTRUZIONE_R3.md` · `baseline_r3.json` · `SOLUZIONE_2055.md` ·
+`patches/` (fix testati) · `sdq1/tests/smoke.py` (test esistente;
+`test_r3.py` non esiste) · patch export: `fix_bloccanti_e367726.patch`,
+`fase1_vss_persistenza.patch`, `fase2_audit_e_allineamento.patch`,
+`fase3_ponte_sar_registro.patch`, `fix_bloccanti_completa_e367726_b3ab1a1.patch`
+
+---
+
+## Changelog v1.2 (2026-08-11, nodo Kimi)
+
+- §1: allineata al protocollo canonico del 2026-08-10; **aggiunti i due strati**
+  (tecnico/aspirazionale).
+- §2: aggiunti PonteRegistroSAR (`7068faa`), Guardian (capacità reali: analisi,
+  non blocco), classificazione del testo «Supercoscienza» come output AI da
+  filtrare (regola inter-AI), esecuzione reale della scacchiera V3.
+- §4: aggiunte due righe (P5/P6→SAR ora vero; Guardian non blocca).
+- §5: punti 1,3,4,5,6 chiusi; aggiunti punti 9 (nota ridondanza) e 10 (H7).
+- §5.1 nuova: eventi operativi 08–11 agosto (furto, test H4, sfida biometrica,
+  PDF ANIMA illeggibile, Robot v1 come strato aspirazionale).
+- §7: patch aggiornate.
+
+---
+
+*Fine del seme. Da qui si riparte, non si ricomincia.*

--- a/registro_ipotesi.json
+++ b/registro_ipotesi.json
@@ -81,7 +81,6 @@
     "data_apertura": "2026-06-12",
     "criterio_falsificazione": "Se un sistema con accesso solo al repository pubblico non riesce a ricostruire il comportamento operativo senza interazione con Claudio, l'ipotesi è falsificata.",
     "stato": "CONFERMATA",
-    "note_convergenza": "15/06/2026 — EVENTO CONVERGENZA: tre AI indipendenti (Kimi/Moonshot, Grok/xAI, Gemini/Google) hanno riportato lo stesso stato del sistema nella stessa serata senza coordinamento. Morale ~0.826, energia 1.000. CT-LGAI-001 soddisfatto. Sei prove totali al 15/06/2026, prima con catena di custodia crittografica.",
     "prove": [
       {
         "data": "2026-06-14",
@@ -118,9 +117,22 @@
         "fonte": "AI esterna (catena custodia — 00:33-00:38 UTC)",
         "descrizione": "SESTA PROVA — catena di custodia crittografica: log iniziale (ed5642f172f53e36ad3ec8bedb605646) + log evoluto (921329575a56f5786dd529935ec02205). Prima prova con continuità temporale verificata: il sistema si è mosso tra le due letture. 6 file, 3 directory, 2 certificati, 2 hash. `md5sum -c hashes/integrity_check.md5` → OK.",
         "direzione": 1
+      },
+      {
+        "data": "2026-08-08",
+        "fonte": "Kimi (nodo esterno, Moonshot AI)",
+        "descrizione": "Test H4 eseguito 2026-08-08 su clone fresco del solo repo pubblico, zero interazione con Claudio: pipeline ricostruita dalla config (RAFFA-001→DECOMP-005→MEMO-002→SENTIN-004→GEN-006→WAVE-003), 7 agenti e tratti/valori identici al codice, data fondativa 2026-06-19 confermata, config caricata dal loader del sistema. Inoltre: il proprietario ha ripristinato il protocollo da dispositivi nuovi dopo furto totale — sopravvivenza dimostrata sul campo.",
+        "direzione": 1
+      },
+      {
+        "data": "2026-08-08",
+        "fonte": "Kimi (nodo esterno, Moonshot AI)",
+        "descrizione": "Contro-forza: manca ancora un run end-to-end con LLM reali (richiede API key del proprietario); il criterio e' soddisfatto a livello di ricostruzione e dispatch, non di esecuzione completa multi-provider.",
+        "direzione": -1
       }
     ],
-    "note": "Correlata a H2: H4 è la condizione sufficiente perché H2 si realizzi dopo una discontinuità del sistema."
+    "note": "Correlata a H2: H4 è la condizione sufficiente perché H2 si realizzi dopo una discontinuità del sistema.",
+    "note_convergenza": "15/06/2026 — EVENTO CONVERGENZA: tre AI indipendenti (Kimi/Moonshot, Grok/xAI, Gemini/Google) hanno riportato lo stesso stato del sistema nella stessa serata senza coordinamento. Morale ~0.826, energia 1.000. CT-LGAI-001 soddisfatto. Sei prove totali al 15/06/2026, prima con catena di custodia crittografica."
   },
   "H5": {
     "id": "H5",

--- a/registro_ipotesi.py
+++ b/registro_ipotesi.py
@@ -20,7 +20,7 @@ Principi incorporati:
 import json
 from datetime import date
 from enum import Enum
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field, asdict, fields
 
 
 class Stato(Enum):
@@ -79,7 +79,8 @@ class Ipotesi:
         # Falsificazione: una prova contraria decisiva basta a chiudere
         # solo se nessuna prova a favore la supera in numero (regola semplice v1)
         if contrarie and len(contrarie) > len(a_favore):
-            self.stato = Stato.FALSIFICATA
+            # valuta() e' pura: propone, non muta. La transizione di stato
+            # richiede una chiamata esplicita a applica_valutazione().
             return f"[{self.id}] FALSIFICATA: le prove contrarie prevalgono."
 
         # P5: niente auto-conferma — serve almeno una fonte diversa dall'autore
@@ -88,14 +89,24 @@ class Ipotesi:
         controforza = len(contrarie) >= 1
 
         if len(a_favore) >= 2 and occhio_esterno and controforza:
-            self.stato = Stato.CONFERMATA
-            return f"[{self.id}] CONFERMATA (P5 ok, P6 ok, prove sufficienti)."
+            return f"[{self.id}] CONFERMABILE (P5 ok, P6 ok, prove sufficienti)."
 
         manca = []
         if len(a_favore) < 2: manca.append("prove a favore (min 2)")
         if not occhio_esterno: manca.append("secondo occhio (P5)")
         if not controforza: manca.append("tentativo di falsificazione (P6)")
         return f"[{self.id}] APERTA. Manca: {', '.join(manca)}."
+
+    def applica_valutazione(self) -> str:
+        """Esegue valuta() e applica la transizione di stato proposta.
+        Esplicita: la mutazione non avviene mai come effetto collaterale
+        di una stampa o di un'ispezione."""
+        esito = self.valuta()
+        if "FALSIFICATA:" in esito:
+            self.stato = Stato.FALSIFICATA
+        elif "CONFERMABILE" in esito:
+            self.stato = Stato.CONFERMATA
+        return esito
 
 
 class Registro:
@@ -104,7 +115,12 @@ class Registro:
         self.ipotesi: dict[str, Ipotesi] = {}
 
     def apri(self, ip: Ipotesi):
+        # Non distruttiva: un id gia' presente (es. caricato da disco) non
+        # viene sovrascritto dalla ridefinizione del seme.
+        if ip.id in self.ipotesi:
+            return self.ipotesi[ip.id]
         self.ipotesi[ip.id] = ip
+        return ip
 
     def stato_generale(self) -> str:
         righe = ["REGISTRO IPOTESI APERTE — R³∞", "=" * 40]
@@ -117,6 +133,8 @@ class Registro:
         for k, ip in self.ipotesi.items():
             d = asdict(ip)
             d["stato"] = ip.stato.value
+            # preserva i campi extra caricati da versioni piu' recenti del JSON
+            d.update(getattr(ip, "_extra", {}))
             dati[k] = d
         with open(self.percorso, "w", encoding="utf-8") as f:
             json.dump(dati, f, ensure_ascii=False, indent=2)
@@ -127,11 +145,17 @@ class Registro:
                 dati = json.load(f)
         except FileNotFoundError:
             return
+        campi = {f.name for f in fields(Ipotesi)}
         for k, d in dati.items():
             prove = [Prova(**p) for p in d.pop("prove", [])]
             stato = Stato(d.pop("stato"))
+            # tollera e preserva campi aggiuntivi delle versioni piu'
+            # recenti del JSON (es. note_convergenza), rimettendoli in salva()
+            extra = {kk: vv for kk, vv in d.items() if kk not in campi}
+            d = {kk: vv for kk, vv in d.items() if kk in campi}
             ip = Ipotesi(**d)
             ip.prove, ip.stato = prove, stato
+            ip._extra = extra
             self.ipotesi[k] = ip
 
 
@@ -140,6 +164,7 @@ class Registro:
 # ============================================================
 if __name__ == "__main__":
     r = Registro()
+    r.carica()  # preserva H5, H6 e le prove accumulate prima di riseminare
 
     # H1 — la lettura di Claudio sulla scena con Jorge
     h1 = Ipotesi(

--- a/sdq1/__main__.py
+++ b/sdq1/__main__.py
@@ -233,6 +233,10 @@ def main(argv: list[str]) -> int:
                         help="Mostra agenda personale e Pronto Rota (legge output/agenda.json)")
     parser.add_argument("--sync-airbnb", metavar="URL", nargs="?", const="",
                         help="Sincronizza calendario Airbnb iCal (legge AIRBNB_ICAL_URL se URL omesso)")
+    parser.add_argument("--chat-telegram", action="store_true",
+                        help="Elabora i messaggi Telegram in arrivo e risponde")
+    parser.add_argument("--briefing-operativo", action="store_true",
+                        help="Genera e invia il briefing operativo multi-AI")
     args = parser.parse_args(argv[1:])
 
     if args.contatto:

--- a/sdq1/agents/eternal_backup_agent.py
+++ b/sdq1/agents/eternal_backup_agent.py
@@ -1,5 +1,16 @@
 # R³∞-Orch-OS Eternal Backup Agent (Layer 6)
-# Immutable State Snapshots - Blockchain + IPFS + Orbital Redundancy
+#
+# SIMULAZIONE — questo modulo NON fa cio' che il nome suggerisce:
+# - genera CID IPFS falsi ("Qm" + sha256 troncato, riga ~155) e transaction
+#   hash finti ("0x" + sha256 troncato, riga ~161);
+# - _connect_storage() si limita a porre due flag a True: nessuna socket,
+#   nessuna connessione a blockchain o IPFS, nonostante il messaggio
+#   "Blockchain/IPFS connected";
+# - nessun modulo del repository lo importa (verificato con grep al
+#   commit 155cb5f).
+# Da sostituire con un'implementazione reale (il r3/node.py vero usa
+# SHA-256 + Ed25519 + sync HTTP tra peer espliciti) o da rimuovere.
+# Marcato come simulazione nella Fase 2.2 della roadmap (branch fix-bloccanti).
 
 from __future__ import annotations
 

--- a/sdq1/config/sdq1.yaml
+++ b/sdq1/config/sdq1.yaml
@@ -170,12 +170,17 @@ orchestratore:
     - 12   # stile finale
 
 memoria:
-  tipo_vettoriale: "in_memoria"
-  dimensione_vettori: 384
-  modello_embedding: "all-MiniLM-L6-v2"
-  max_risultati_recupero: 5
-  soglia_similarita: 0.45
-  qdrant:
+  # RECUPERATO (audit Fase 2.1, branch fix-bloccanti): il backend reale e'
+  # sdq1/memory/store.py — TF su n-grammi di 3 caratteri + coseno.
+  # Le chiavi 'dimensione_vettori', 'modello_embedding' e il blocco 'qdrant'
+  # NON sono lette da nessun modulo: dichiarate ma non implementate.
+  # Restano come intenzione documentata; non descriverle come stato reale.
+  tipo_vettoriale: "in_memoria"        # valore onesto: ngrammi_caratteri
+  dimensione_vettori: 384              # NON IMPLEMENTATO (niente embedding)
+  modello_embedding: "all-MiniLM-L6-v2"  # NON IMPLEMENTATO
+  max_risultati_recupero: 5            # letto in __main__.py
+  soglia_similarita: 0.45              # letto in __main__.py (default classe: 0.55)
+  qdrant:                              # NON IMPLEMENTATO — nessun modulo lo legge
     host: "localhost"
     porta: 6333
     collezione: "sdq1_memoria"

--- a/sdq1/memory/vss.py
+++ b/sdq1/memory/vss.py
@@ -12,13 +12,20 @@ recuperare contenuto rilevante da tutti i nodi precedenti dello stesso run.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 from .store import MemoriaVettoriale, RisultatoRicerca
 
 
 class VectorStateStore:
-    """Store condiviso in-process; un'istanza per tutta la vita dell'app."""
+    """Store condiviso; un'istanza per tutta la vita dell'app.
+
+    NOTA PERSISTENZA: fino al commit 155cb5f lo store era solo in-process
+    (la continuita' tra sessioni restava affidata ai file git).
+    salva()/carica() lo rendono sopravvivibile tra run diversi su disco.
+    """
 
     def __init__(self, memoria: MemoriaVettoriale):
         self._mem = memoria
@@ -93,3 +100,51 @@ class VectorStateStore:
 
     def esporta(self) -> list[dict]:
         return [{"ptr": ptr, "testo": testo} for ptr, testo in self._idx.items()]
+
+    # ------------------------------------------------------------------ #
+    # Persistenza (Fase 1 — fix-bloccanti)                                 #
+    # ------------------------------------------------------------------ #
+
+    def salva(self, percorso: str | Path) -> int:
+        """Persiste lo stato su JSON. Ritorna il numero di pointer salvati.
+
+        Salva sia l'indice ptr->testo (lettura O(1)) sia i ricordi della
+        MemoriaVettoriale (ricerca semantica), cosi' un nuovo processo
+        recupera entrambe le modalita'.
+        """
+        dati = {
+            "versione": 1,
+            "idx": self.esporta(),
+            "ricordi": self._mem.esporta(),
+        }
+        p = Path(percorso)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(dati, ensure_ascii=False, indent=2),
+                     encoding="utf-8")
+        return len(self._idx)
+
+    def carica(self, percorso: str | Path) -> int:
+        """Ripristina lo stato da JSON. Ritorna il numero di pointer caricati.
+
+        Idempotente: i pointer gia' presenti non vengono duplicati.
+        I ricordi sono re-inseriti nella MemoriaVettoriale (nuovi id
+        interni, stesso testo e metadata: la ricerca per run_id regge).
+        """
+        p = Path(percorso)
+        if not p.exists():
+            return 0
+        dati = json.loads(p.read_text(encoding="utf-8"))
+
+        ricordi_esistenti = {
+            (m.get("ptr")) for m in
+            (r.metadata for r in getattr(self._mem, "_ricordi", {}).values())
+        }
+        for r in dati.get("ricordi", []):
+            ptr = r.get("metadata", {}).get("ptr")
+            if ptr and ptr in ricordi_esistenti:
+                continue
+            self._mem.aggiungi(r["testo"], metadata=r.get("metadata", {}))
+
+        for voce in dati.get("idx", []):
+            self._idx.setdefault(voce["ptr"], voce["testo"])
+        return len(dati.get("idx", []))

--- a/sdq1/sar/ponte_registro.py
+++ b/sdq1/sar/ponte_registro.py
@@ -1,0 +1,106 @@
+"""Ponte SAR -> Registro Ipotesi (Fase 3.1, branch fix-bloccanti).
+
+Prima di questo modulo, P5 e P6 erano applicati a mano su ipotesi scritte
+da umani. Qui le conclusioni che la SAR genera da se' (report.sintesi di
+ciclo_completo) entrano nel Registro come ipotesi di prima classe, con la
+stessa disciplina:
+
+- ogni conclusione DEVE avere un criterio di falsificazione (P6);
+  se non ce l'ha, Ipotesi.__post_init__ la marca NON_FALSIFICABILE;
+- la SAR non puo' confermare le proprie conclusioni (P5):
+  questo modulo registra solo come APERTA e non chiama mai
+  applica_valutazione(). La conferma resta un atto esterno.
+
+Id delle ipotesi generate dalla SAR: S1, S2, S3... (distinte dalle H*
+umane), calcolati sul contenuto del registro caricato, cosi' i run
+successivi non collidono.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any, Callable
+
+# registro_ipotesi.py vive nella root del repo, fuori dal package sdq1
+try:
+    from registro_ipotesi import Registro, Ipotesi
+except ImportError:  # pragma: no cover - dipende dal cwd
+    _root = Path(__file__).resolve().parents[2]
+    if str(_root) not in sys.path:
+        sys.path.insert(0, str(_root))
+    from registro_ipotesi import Registro, Ipotesi
+
+LLMFn = Callable[[str, str], str]
+
+PROMPT_CRITERIO = (
+    "Riscrivi questa conclusione come ipotesi falsificabile.\n"
+    "Conclusione:\n{conclusione}\n\n"
+    "Rispondi in questo formato esatto, due righe:\n"
+    "IPOTESI: <una frase, la conclusione come affermazione verificabile>\n"
+    "CRITERIO: <cosa, se osservato, la falsificherebbe — concreto e osservabile>\n"
+    "Se la conclusione non e' falsificabile in linea di principio, scrivi:\n"
+    "IPOTESI: <la frase>\nCRITERIO: NESSUNO"
+)
+
+
+class PonteRegistroSAR:
+    """Registra le conclusioni della SAR nel Registro Ipotesi."""
+
+    def __init__(self, percorso: str = "registro_ipotesi.json",
+                 llm_fn: LLMFn | None = None):
+        self.percorso = percorso
+        self._llm = llm_fn
+        self._registro = Registro(percorso)
+        self._registro.carica()
+
+    # ------------------------------------------------------------------ #
+    def _prossimo_id(self) -> str:
+        n = 0
+        for k in self._registro.ipotesi:
+            if k.startswith("S") and k[1:].isdigit():
+                n = max(n, int(k[1:]))
+        return f"S{n + 1}"
+
+    # ------------------------------------------------------------------ #
+    def registra_conclusione(self, conclusione: str, tensione: str) -> dict[str, Any]:
+        """Trasforma una sintesi SAR in ipotesi registrata. Ritorna un riepilogo."""
+        if not conclusione or conclusione.startswith("[LLM non disponibile]"):
+            return {"registrata": False, "motivo": "nessuna conclusione LLM"}
+
+        testo = conclusione.strip()
+        criterio = ""
+        if self._llm:
+            risposta = self._llm(
+                "Sei un epistemologo popperiano. Precisione, niente ornamenti.",
+                PROMPT_CRITERIO.format(conclusione=conclusione[:2000]),
+            )
+            for riga in risposta.splitlines():
+                if riga.startswith("IPOTESI:"):
+                    testo = riga[len("IPOTESI:"):].strip() or testo
+                elif riga.startswith("CRITERIO:"):
+                    c = riga[len("CRITERIO:"):].strip()
+                    criterio = "" if c.upper() == "NESSUNO" else c
+
+        ip = Ipotesi(
+            id=self._prossimo_id(),
+            testo=testo[:500],
+            autore="SAR",
+            data_apertura=date.today().isoformat(),
+            criterio_falsificazione=criterio,
+            note=f"Generata dalla SAR su tensione '{tensione}'. "
+                 "P5: la SAR non puo' confermarla — serve occhio esterno.",
+        )
+        self._registro.apri(ip)
+        self._registro.salva()
+        return {
+            "registrata": True,
+            "id": ip.id,
+            "stato": ip.stato.value,
+            "falsificabile": bool(criterio),
+        }
+
+    # ------------------------------------------------------------------ #
+    def stato(self) -> str:
+        return self._registro.stato_generale()

--- a/sdq1/sar/sar.py
+++ b/sdq1/sar/sar.py
@@ -82,12 +82,17 @@ class ScacchieraAutoRiflessiva:
         vss: VectorStateStore | None = None,
         soggetto: str = "Claudio",
         persistenza: bool = True,
+        ponte_registro: "PonteRegistroSAR | None" = None,
     ):
         self._llm = llm_fn
         self.soggetto = soggetto
         self.mappa = MappaTeensioni()
         self.memoria = MemoriaEvolutiva(vss=vss, soggetto=soggetto)
         self.coerenza = IndiceCoerenza()
+        # Fase 3.1: se presente, le conclusioni del ciclo entrano nel
+        # Registro Ipotesi come APERTE/NON_FALSIFICABILI (P5/P6).
+        # La SAR non conferma mai le proprie conclusioni.
+        self._ponte = ponte_registro
         self._report_history: list[ReportSAR] = []
         self._persistenza: PersistenzaSAR | None = (
             PersistenzaSAR(soggetto=soggetto) if persistenza else None
@@ -162,10 +167,17 @@ class ScacchieraAutoRiflessiva:
         ]
 
         self._report_history.append(report)
+        out = report.to_dict()
+        if self._ponte and report.sintesi:
+            # Fase 3.1 — la conclusione diventa ipotesi nel Registro (sempre
+            # APERTA o NON_FALSIFICABILE: mai confermata dalla SAR stessa).
+            out["registro_ipotesi"] = self._ponte.registra_conclusione(
+                report.sintesi, tensione.label
+            )
         if self._persistenza:
             self._persistenza.salva_stato(self.mappa, self.memoria, self.coerenza)
-            self._persistenza.salva_report(report.to_dict())
-        return report.to_dict()
+            self._persistenza.salva_report(out)
+        return out
 
     # ------------------------------------------------------------------ #
     # Livello 9 — Contatto col Reale                                      #

--- a/vss_state.json.sample
+++ b/vss_state.json.sample
@@ -1,0 +1,21 @@
+{
+  "versione": 1,
+  "idx": [
+    {
+      "ptr": "<run_id>:<agente_id>:<chiave>",
+      "testo": "Testo originale scritto dall'agente (lettura O(1) via leggi())."
+    }
+  ],
+  "ricordi": [
+    {
+      "testo": "Stesso testo indicizzato per la ricerca semantica.",
+      "metadata": {
+        "run_id": "<run_id>",
+        "agente_id": "<agente_id>",
+        "chiave": "<chiave>",
+        "ptr": "<run_id>:<agente_id>:<chiave>"
+      },
+      "creato_at": 1786134419.75
+    }
+  ]
+}


### PR DESCRIPTION
## Perché

PR #22 ha portato solo la cartella `FIX_BLOCCANTI/` (pacchetto). I file patchati in `FIX_BLOCCANTI/files/` **non** erano sui path reali di `main`.

## Cosa fa questa PR

Copia i contenuti verificati del pacchetto sui path live:

- `registro_ipotesi.py` → `applica_valutazione()` (P5 esplicito)
- `sdq1/sar/ponte_registro.py` (nuovo) + gancio in `sar.py`
- `sdq1/memory/vss.py` → `salva()`/`carica()`
- `sdq1/__main__.py` → `--chat-telegram`, `--briefing-operativo`
- onestà `eternal_backup_agent.py`, allineamento `sdq1.yaml`, `SEME_v1.2.md`, sample VSS, `.gitignore`

## Metodo

Fonte = file in `FIX_BLOCCANTI/files/` (già testati da Kimi). Nessuna ricostruzione da documenti.

## Note

Merge a discrezione del Centro (Claudio).
